### PR TITLE
Add Las Vegas to county map

### DIFF
--- a/lib/county-map.json
+++ b/lib/county-map.json
@@ -70,6 +70,9 @@
         "Lincoln": ["Lancaster County"],
         "Omaha": ["Douglas County"]
     },
+    "Nevada": {
+        "Las Vegas": ["Clark County"]
+    },
     "New Jersey": {
         "Newark": ["Essex County"],
         "Jersey City": ["Hudson County"]


### PR DESCRIPTION
The data now includes an entry for Las Vegas, so it needs to be associated with a county.

## Additions

- Nevada entry in the county map with a county array for Las Vegas



## Testing

1. Check out branch
2. Run script against latest data
3. Verify that county array is added to Las Vegas program 
