### PR TITLE
Add Durham to NC map

### DIFF
--- a/lib/county-map.json
+++ b/lib/county-map.json
@@ -97,6 +97,7 @@
     },
     "North Carolina": {
         "Charlotte": ["Mecklenburg County"],
+        "Durham": ["Durham County"],
         "Greensboro": ["Guilford County"],
         "Winston-Salem": ["Forsyth County"]
     },


### PR DESCRIPTION
Add an entry for Durham, NC to the counties map

## Additions

- Durham entry in counties map


## Testing

1. Check out branch and run script. 
2. Verify that correct county is added to Durham entry in output file.

