### PR TITLE
Hide additional closed programs

### DIFF
--- a/erap-data-processing.js
+++ b/erap-data-processing.js
@@ -119,8 +119,8 @@ const processPrograms = ( programs ) => {
 
     if ( itemCopy.type === 'Tribal Government' ) {
       results.tribal.push(itemCopy);
-    } else if ( ( itemCopy.type === 'State' && itemCopy.state === 'Texas' ) ||
-                itemCopy.state === 'Mississippi' ) {
+    } else if ( itemCopy.type === 'State' && ( itemCopy.state === 'Texas' ||
+                itemCopy.state === 'Mississippi' ) ) {
       // Temporary fix to hide closed programs
     } else {
       results.geographic.push(itemCopy);

--- a/erap-data-processing.js
+++ b/erap-data-processing.js
@@ -119,9 +119,9 @@ const processPrograms = ( programs ) => {
 
     if ( itemCopy.type === 'Tribal Government' ) {
       results.tribal.push(itemCopy);
-    } else if ( itemCopy.type === 'State' && itemCopy.state === 'Texas' ) {
-      // Do something with closed programs
-      // This is just a quick fix to hide Texas's state program
+    } else if ( ( itemCopy.type === 'State' && itemCopy.state === 'Texas' ) ||
+                itemCopy.state === 'Mississippi' ) {
+      // Temporary fix to hide closed programs
     } else {
       results.geographic.push(itemCopy);
     }


### PR DESCRIPTION

## Additions

- Code to hide Mississippi programs from results

## Testing

1. Check out branch and run script. Verify that Mississippi programs are not included in erap.json output.

